### PR TITLE
VCST-2022: Bump YamIDotNet to the latest 16.1.3

### DIFF
--- a/src/VirtoCommerce.Contentful.Web/Controllers/Api/ContentfulController.cs
+++ b/src/VirtoCommerce.Contentful.Web/Controllers/Api/ContentfulController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/VirtoCommerce.Contentful.Web/VirtoCommerce.Contentful.Web.csproj
+++ b/src/VirtoCommerce.Contentful.Web/VirtoCommerce.Contentful.Web.csproj
@@ -17,13 +17,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="contentful.csharp" Version="7.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Data" Version="3.800.0" />
-    <PackageReference Include="VirtoCommerce.ContentModule.Data" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.800.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.800.0" />
-    <PackageReference Include="YamlDotNet.NetCore" Version="1.0.0" />
+    <PackageReference Include="YamlDotNet" Version="16.1.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
feat: Bump YamIDotNet to the latest 16.1.3

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2022
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Contentful_3.802.0-pr-11-6080.zip