### PR TITLE
VCST-4848: Add VirtoCommerce.Pages.Core.dll to module.keep

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Module CI
 
 on:
@@ -53,7 +53,6 @@ jobs:
       version: ${{ steps.artifact_ver.outputs.shortVersion }}
       moduleId: ${{ steps.artifact_ver.outputs.moduleId }}
       matrix: ${{ steps.deployment-matrix.outputs.matrix }}
-      run-e2e: ${{ steps.run-e2e.outputs.result }}
       deployment-folder-exists: ${{ steps.check_deployment_folder.outputs.exists }}
       requiredModulesListUrl: ${{ steps.extract_required_modules_list_url_from_pr.outputs.url }}
 
@@ -210,18 +209,6 @@ jobs:
           deployConfigPath: '.deployment/module/cloudDeploy.json'
           releaseBranch: 'master'
 
-      - name: Check commit message for version number
-        id: run-e2e
-        env:
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-        run: |
-          if [[ "$COMMIT_MESSAGE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]];
-          then
-            echo "result=false" >> $GITHUB_OUTPUT
-          else
-            echo "result=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Extract required modules list URL from the pull request description
         if: ${{ github.event_name == 'pull_request' }}
         id: extract_required_modules_list_url_from_pr
@@ -298,11 +285,11 @@ jobs:
         run: |
           echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
 
-  ui-auto-tests:
+  auto-tests:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
-    needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
+    needs: ci
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -311,37 +298,18 @@ jobs:
       requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
       vctestingRepoBranch: 'dev'
       frontendZipUrl: 'latest'
+      testSuites: 'graphql,restapi'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
-
-  module-katalon-tests:
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
-        (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.29
-    with:
-      katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
-      katalonRepoBranch: 'dev'
-      testSuite: 'Test Suites/Modules/Platform_collection'
-      installModules: 'false'
-      installCustomModule: 'true'
-      customModuleId:  ${{ needs.ci.outputs.moduleId }}
-      customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
-      requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
-      platformDockerTag: 'dev-linux-latest'
-      storefrontDockerTag: 'dev-linux-latest'
-    secrets:
-      envPAT: ${{ secrets.REPO_TOKEN }}
-      katalonApiKey: ${{ secrets.KATALON_API_KEY }}
 
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.29
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.30
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/.github/workflows/module-release-hotfix.yml
+++ b/.github/workflows/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.29
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.29
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Publish nuget
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.29
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release
 
 on:
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.30    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/module.ignore
+++ b/module.ignore
@@ -1,2 +1,1 @@
 TimeZoneConverter.dll
-VirtoCommerce.Pages.Core.dll

--- a/module.keep
+++ b/module.keep
@@ -1,0 +1,1 @@
+VirtoCommerce.Pages.Core.dll


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4848
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Contentful_3.1001.0-pr-14-a975.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/CD behavior changes (test suite selection and removal of Katalon E2E) can alter test coverage and release confidence. No runtime product code changes are included.
> 
> **Overview**
> Updates the GitHub Actions workflows to use VirtoCommerce shared workflows `v3.800.30` across CI, release, hotfix, and NuGet publishing.
> 
> In `module-ci.yml`, replaces the `ui-autotests` workflow with `pytest-tests.yml` (running `graphql,restapi` suites) and removes the commit-message-based `run-e2e` gating plus the entire Katalon `module-katalon-tests` job.
> 
> Adjusts module packaging lists by moving `VirtoCommerce.Pages.Core.dll` from `module.ignore` into a new `module.keep` file so it is preserved in the module output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a97590e90c66aa0f38ece07a193f75badc2a8dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->